### PR TITLE
Improve timeZone addon

### DIFF
--- a/manifest.jps
+++ b/manifest.jps
@@ -2,14 +2,13 @@ id: timetz
 type: update
 logo: https://raw.githubusercontent.com/jelastic-jps/time-zone-change/master/images/timezone-logo.png
 description:
-  text: "To set the needed Time Zone settings find it at TZ database name column and paste it to TimeZone Name field.  \n\nExample: America/Fortaleza. \n\n[List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)"
+  text: "Choose Time Zone from dropdown list.  \n\nExample: America/Fortaleza"
   short: TimeZone Change Tool
 name: TimeZone Change
 onBeforeInit: |
-  var url = "http://worldtimeapi.org/api/timezone";
-  var zones = toNative(new com.hivext.api.core.utils.Transport().get(url)).sort();
+  var zones = toNative(java.time.ZoneId.getAvailableZoneIds()).sort();
+  var serverTimeZone = toNative(java.time.ZoneId.systemDefault());
   var values = {};
-  
   for (var i = 0, n = zones.length; i < n; i++) {
     values[zones[i]] = zones[i];
   }
@@ -18,29 +17,29 @@ onBeforeInit: |
     result: 0,
     settings: {
       fields: [{
-        name: "dashoard_url",
+        name: "timeZone",
         caption: "TimeZone Name",
         type: "list",
         required: true,
         editable: true,
+        "default": serverTimeZone,
         values: values
       }]
     }
   }
-  
+
 categories:
 - apps/dev-tools
 onInstall: installAgent
 actions:
   installAgent:
-  - forEach(env.nodes):
-    - cmd [${@i.nodeType}]:
-      - echo "=== OLD TimeZone settings for ${@i.nodeType} ===" >> /var/log/jpsaddon.log
-      - timedatectl  >> /var/log/jpsaddon.log
-      - ln -sf /usr/share/zoneinfo/${settings.dashoard_url} /etc/localtime
-      - echo "=== NEW TimeZone ${settings.dashoard_url} has been set for ${@i.nodeType} ===" >> /var/log/jpsaddon.log
-      - timedatectl  >> /var/log/jpsaddon.log
+    - cmd[*]: |-
+        echo "=== OLD TimeZone settings ===" >> /var/log/jpsaddon.log
+        date  >> /var/log/jpsaddon.log
+        ln -sf /usr/share/zoneinfo/${settings.timeZone} /etc/localtime
+        echo "=== NEW TimeZone ${settings.timeZone} has been set ===" >> /var/log/jpsaddon.log
+        date  >> /var/log/jpsaddon.log
       user: root
-    - restartNodes [${@i.nodeType}]
+    - restartNodes[*]
 version: '0.3'
-success: Your TimeZone was changed to ${settings.dashoard_url}
+success: Your TimeZone was changed to ${settings.timeZone}


### PR DESCRIPTION
This PR introduces minor changes aimed at improving the addon:

* get time zones from Java rather than get them from an external source
* set default time zone in the wizard
* avoid forEach but execute cmd asynchronously
* replace `timedatectl` with `date` since `timedatectl` isn't available in all Linux distros and odds are that the command is missing. Since it is used just to write nice output to log, using standard `date` command sounds more reasonable.